### PR TITLE
Fixed TypeError: a bytes-like object is required, not 'int'

### DIFF
--- a/ScanUtility.py
+++ b/ScanUtility.py
@@ -104,7 +104,10 @@ def parse_events(sock, loop_count=100):
             scrambledAddress = dataString[14:26]
             fixStructure = iter("".join(reversed([scrambledAddress[i:i+2] for i in range(0, len(scrambledAddress), 2)])))
             macAddress = ':'.join(a+b for a,b in zip(fixStructure, fixStructure))
-            rssi, = struct.unpack("b", packet[packetOffset -1])
+            if sys.version_info[0] == 3:
+                rssi, = struct.unpack("b", bytes([packet[packetOffset-1]]))
+            else:
+                rssi, = struct.unpack("b", packet[packetOffset-1])
 
             resultsArray = [{"type": type, "uuid": uuid, "major": majorVal, "minor": minorVal, "rssi": rssi, "macAddress": macAddress}]
 


### PR DESCRIPTION
Fixed Exception in python3:
  File "BeaconScanner.py", line 19, in <module>
    returnedList = ScanUtility.parse_events(sock, 10)
  File "/home/pi/BLE-Beacon-Scanner/ScanUtility.py", line 107, in parse_events
    rssi, = struct.unpack("b", packet[packetOffset -1])
TypeError: a bytes-like object is required, not 'int'