### PR TITLE
fixed bug where if condition always true

### DIFF
--- a/ScanUtility.py
+++ b/ScanUtility.py
@@ -43,7 +43,7 @@ def parse_events(sock, loop_count=100):
         If the bluetooth device is an beacon then show the beacon.
         """
         #print (dataString)
-        if dataString[34:50] == '0303aafe1516aafe' or '0303AAFE1116AAFE':
+        if (dataString[34:42] == '0303aafe') and (dataString[44:50] == '16AAFE'):
             """
             Selects parts of the bluetooth packets.
             """


### PR DESCRIPTION
This fix addresses two issues:

1) The iff condition is always true because a nonempty string evaluates to True.
(dataString[34:50] == '0303aafe1516aafe' or '0303AAFE1116AAFE') is equivalent to (dataString[34:50] == '0303aafe1516aafe' or True). 

2) dataString[42:43] contains the length of data. When checking for the type of beacon, this check limits advertisements to 11 or 15 bytes only. 